### PR TITLE
update timeout and step back puppeteer versions

### DIFF
--- a/crawlerapp/package.json
+++ b/crawlerapp/package.json
@@ -17,7 +17,7 @@
     "cheerio": "^1.0.0-rc.3",
     "express": "^4.16.4",
     "mime": "^2.4.3",
-    "puppeteer": "^1.15.0",
+    "puppeteer": "^1.11.0",
     "request": "^2.88.0",
     "robots-parser": "^2.1.1",
     "valid-url": "^1.0.9"


### PR DESCRIPTION
Updated the timeout to 10s and fire off errors when it is exceeded.  Also added more error handling so it sends a failure reason back to the front end.  Had to step back a few versions on Puppeteer, there is a known issue with some websites that will cause it to freeze.  Thankfully we don't need the features in the newer versions of puppeteer but I may remove iframe compatibility instead in the future for security reasons.